### PR TITLE
Make Readme more verbose and readable

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ When this app is installed, it provides discounts to new users.
 
 ## Configuration in Rebilly
 
-1. Follow instructions to submit you application in [Rebilly App Store guide](https://www.rebilly.com/docs/content/concepts-and-features/tutorial/create-a-rebilly-app/#submit-an-app-to-the-app-store).
+1. [Submit an app to the Rebilly App Store](https://www.rebilly.com/docs/content/concepts-and-features/tutorial/submit-a-rebilly-app.md).
 1. Deploy this Lambda function and receive an invocation URL.
 1. In Rebilly, in the left navigation bar, click **Automations**, then click **Rules engine**.
 1. Click **Core events**, and select the **Application instance enabled** event.


### PR DESCRIPTION
I think this is still missing a bit of info, but I think this isn't live in the Rebilly UI yet, so it's understandable. The docs site also needs info on how to install apps, again I think this is early, I'm just reminding 😃 

I'll add the image tomorrow, I edited in the GitHub web editor.