### PR TITLE
Correct typo in locked urllib3 version

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,2 +1,2 @@
 requests==2.31.0
-urllib3=1.26.15
+urllib3==1.26.15


### PR DESCRIPTION
```bash
 pip install -r requirements.txt 
Collecting requests==2.31.0
  Using cached requests-2.31.0-py3-none-any.whl (62 kB)
Collecting urllib3==1.26.15
  Using cached urllib3-1.26.15-py2.py3-none-any.whl (140 kB)
```